### PR TITLE
Fixed CORS for local development

### DIFF
--- a/MorseSignalRServer/Config/CorsConfig.cs
+++ b/MorseSignalRServer/Config/CorsConfig.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Cors.Infrastructure;
 namespace MorseSignalRServer.Config {
     public static class CorsConfig {
         public static string AllowAllOriginsCorsPolicy = "AllowAllOrigins";
+        public static string AllowKnownLocalClientOriginsCorsPolicy = "AllowKnownLocalClientOriginsCorsPolicy";
         public static string AllowKnownClientOriginsCorsPolicy = "AllowKnownClientsOrigins";
         public static void Configure(CorsOptions options) {
             options.AddPolicy(AllowAllOriginsCorsPolicy,
@@ -11,6 +12,17 @@ namespace MorseSignalRServer.Config {
                     builder.AllowAnyOrigin()
                         .AllowAnyHeader()
                         .AllowAnyMethod();
+                });
+
+            options.AddPolicy(AllowKnownLocalClientOriginsCorsPolicy,
+                builder =>
+                {
+                    builder.AllowAnyMethod()
+                        .AllowAnyHeader()
+                        .WithOrigins(
+                            "http://localhost:8080",
+                            "https://localhost:8080")
+                        .AllowCredentials();
                 });
 
             options.AddPolicy(AllowKnownClientOriginsCorsPolicy,

--- a/MorseSignalRServer/Startup.cs
+++ b/MorseSignalRServer/Startup.cs
@@ -50,7 +50,7 @@ namespace MorseSignalRServer
             {
                 app.UseDeveloperExceptionPage();
                 
-                app.UseCors(CorsConfig.AllowAllOriginsCorsPolicy);
+                // app.UseCors(CorsConfig.AllowKnownLocalClientOriginsCorsPolicy);
             } else {
                 // HTTPS redirect rule for runing behind an inverse proxy
                 var options = new RewriteOptions()
@@ -65,6 +65,8 @@ namespace MorseSignalRServer
             app.UseForwardedHeaders();
 
             app.UseRouting();
+
+            app.UseCors(CorsConfig.AllowKnownLocalClientOriginsCorsPolicy);
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
Fixed Cors for local development
> Browsers don't like that  `Access Control Allow Credentials : true` when `Access Control Allow Orgin : *`